### PR TITLE
[BLOCKER] Fix broken test addTextToDiscussion_addsToTopWhenTemplate1SpecifiedLo…

### DIFF
--- a/src/test/java/org/wikipedia/nirvana/WikiUtilsTest.java
+++ b/src/test/java/org/wikipedia/nirvana/WikiUtilsTest.java
@@ -119,7 +119,8 @@ public class WikiUtilsTest {
     public void addTextToDiscussion_addsToTopWhenTemplate1SpecifiedLocalized() {
         TestLocalizationManager.reset();
         Map<String, LocalizedTemplate> localizedTemplates = new HashMap<>();
-        localizedTemplates.put("Новые сверху", new LocalizedTemplate("Add to top", ""));
+        localizedTemplates.put("Новые сверху",
+                new LocalizedTemplate("Новые сверху", "Add to top"));
         TestLocalizationManager.init(null, localizedTemplates);
 
         String discussion =


### PR DESCRIPTION
Fix broken test addTextToDiscussion_addsToTopWhenTemplate1SpecifiedLocalized

in WikiUtilsTest module.

Тест изначально был сломан, не понимаю, почему он не падал в Eclipse.
В консоли mvn test и в Idea (с импортом через pom.xml) тест падал и падал правильно. В тесте был баг.